### PR TITLE
Prefix 'http_' to all http functions

### DIFF
--- a/binnacle/__init__.py
+++ b/binnacle/__init__.py
@@ -1,4 +1,4 @@
 from binnacle.core import debug, show_summary
-from binnacle.plugins.http import get, post, put, delete, validated_json, base_url, set_header
+from binnacle.plugins.http import http_get, http_post, http_put, http_delete, validated_json, base_url, set_header
 from binnacle.plugins.commands import command_run
 from binnacle.plugins.compare import compare_equal, compare_not_equal

--- a/binnacle/__init__.py
+++ b/binnacle/__init__.py
@@ -1,4 +1,4 @@
 from binnacle.core import debug, show_summary
-from binnacle.plugins.http import http_get, http_post, http_put, http_delete, validated_json, base_url, set_header
+from binnacle.plugins.http import http_get, http_post, http_put, http_delete, validated_json, http_base_url, http_set_header
 from binnacle.plugins.commands import command_run
 from binnacle.plugins.compare import compare_equal, compare_not_equal

--- a/binnacle/plugins/http.py
+++ b/binnacle/plugins/http.py
@@ -37,21 +37,21 @@ def full_url(url):
 
 
 @binnacle_task
-def post(url, status = 200, task=None):
+def http_post(url, status = 200, task=None):
     resp = requests.post(full_url(url), headers=_headers)
     task.ok = resp.status_code == status
     return resp
 
 
 @binnacle_task
-def put(url, status = 200, task=None):
+def http_put(url, status = 200, task=None):
     resp = requests.put(full_url(url), headers=_headers)
     task.ok = resp.status_code == status
     return resp
 
 
 @binnacle_task
-def get(url, status = 200, task=None):
+def http_get(url, status = 200, task=None):
     resp = requests.get(full_url(url), headers=_headers)
     task.debug(f"URL: GET {url}\nExpected Status: {status}\nActual Status: {resp.status_code}")
     task.ok = resp.status_code == status
@@ -59,7 +59,7 @@ def get(url, status = 200, task=None):
 
 
 @binnacle_task
-def delete(url, status = 204, task=None):
+def http_delete(url, status = 204, task=None):
     resp = requests.delete(full_url(url), headers=_headers)
     task.ok = resp.status_code == status
     return resp

--- a/binnacle/plugins/http.py
+++ b/binnacle/plugins/http.py
@@ -7,22 +7,22 @@ from binnacle.core import binnacle_task
 _url = ""
 _headers = {}
 
-def base_url(url):
+def http_base_url(url):
     global _url
     _url = url
 
 
-def set_header(name, value):
+def http_set_header(name, value):
     global _headers
     _headers[name] = f"{value}"
 
 
-def remove_header(name):
+def http_remove_header(name):
     global _headers
     del _headers[name]
 
 
-def headers(values):
+def http_headers(values):
     global _headers
     _headers = {}
     for name, value in values.items():

--- a/test_rest_apis.py
+++ b/test_rest_apis.py
@@ -3,15 +3,15 @@ from binnacle import *
 base_url("http://localhost:5001")
 
 # Without API Key
-get("/api/v1/folders", status=403)
+http_get("/api/v1/folders", status=403)
 
 # With wrong API Key
 set_header("x-api-key", "ABC")
-get("/api/v1/folders", status=401)
+http_get("/api/v1/folders", status=401)
 
 # With valid API Key
 set_header("x-api-key", "user_26a5fa8c7d8ad3729d218bcecf38c3aa9a7d4e40106072b4fd3f313af5c0682f")
-data = get("/api/v1/folders")
+data = http_get("/api/v1/folders")
 debug(data)
 folders = validated_json(data)
 

--- a/test_rest_apis.py
+++ b/test_rest_apis.py
@@ -1,16 +1,16 @@
 from binnacle import *
 
-base_url("http://localhost:5001")
+http_base_url("http://localhost:5001")
 
 # Without API Key
 http_get("/api/v1/folders", status=403)
 
 # With wrong API Key
-set_header("x-api-key", "ABC")
+http_set_header("x-api-key", "ABC")
 http_get("/api/v1/folders", status=401)
 
 # With valid API Key
-set_header("x-api-key", "user_26a5fa8c7d8ad3729d218bcecf38c3aa9a7d4e40106072b4fd3f313af5c0682f")
+http_set_header("x-api-key", "user_26a5fa8c7d8ad3729d218bcecf38c3aa9a7d4e40106072b4fd3f313af5c0682f")
 data = http_get("/api/v1/folders")
 debug(data)
 folders = validated_json(data)


### PR DESCRIPTION
Fixes issue #1

1. Rename all http functions with prefix 'http_'
2. Update all the references to this function