### PR TITLE
CLI support to run test files

### DIFF
--- a/binnacle/__init__.py
+++ b/binnacle/__init__.py
@@ -4,4 +4,5 @@ from binnacle.plugins.commands import (
    command_run, command_mode, command_node, command_ssh_user,
    command_ssh_sudo, command_ssh_pem_file, command_port, command_container
 )
-from binnacle.plugins.compare import compare_equal, compare_not_equal
+from binnacle.plugins.compare import (compare_equal, 
+   compare_not_equal)

--- a/binnacle/version.py
+++ b/binnacle/version.py
@@ -1,1 +1,1 @@
-VERSION=0.7.0
+VERSION="0.7.0"

--- a/custom_entry.py
+++ b/custom_entry.py
@@ -1,0 +1,46 @@
+import argparse
+import sys
+import subprocess
+import os
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="CLI tool to run selected files")
+    parser.add_argument(
+        '-v',"--verbose", action='count', default =0, 
+        help='increase verbosity -v, -vv,-vvv')
+    parser.add_argument('paths', 
+                        nargs='+',  # Accepts zero or more positional arguments 
+                        help='Names of the test files to run or test directory')
+    return parser.parse_args()
+
+
+def run_files(file_name,env):
+    print(f"\n[Running] {file_name}")
+    subprocess.run([sys.executable, file_name], env=env, check=True)
+    
+
+def run_directory(direc,env):
+    for root, _, files in os.walk(direc):
+        for file in files:
+            if file.endswith('.py'):
+                full_path = os.path.join(root, file)
+                run_files(full_path,env)
+
+
+def main():
+       
+    args =  parse_args()
+    
+    env = os.environ.copy()
+    if args.verbose:
+       env["DEBUG"]  = "true" #set env variable
+    
+    for path in args.paths:
+        if os.path.isfile(path) and path.endswith('.py'):
+            run_files(path, env) 
+        elif os.path.isdir(path):
+            run_directory(path, env)
+        else:
+            print("File or directory does not exist")

--- a/setup.py
+++ b/setup.py
@@ -21,4 +21,9 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only"
     ],
+    entry_points={
+        'console_scripts':[
+          'binnacle=custom_entry:main',  
+        ],
+    },
 )

--- a/test/test_commands_docker.py
+++ b/test/test_commands_docker.py
@@ -2,10 +2,10 @@ from binnacle import *
 
 #mode 3: docker
 command_mode("docker")
-command_container("server1")
+command_container("server1") #Your docker container name
 
 # Check if report is generated or a file exists in a container
 command_run("echo 'Hello World!' > /root/reports.txt")
 command_run("stat /root/reports.txt") #report exixts
 command_run("stat /root/reports1.txt 2>/dev/null && echo 'File exists' || echo 'File does not exist'") #report1 does not exixt
-
+show_summary()

--- a/test/test_commands_local.py
+++ b/test/test_commands_local.py
@@ -4,4 +4,4 @@ from binnacle import *
 validated_json('{"name": 100}')
 command_run("ls /tmp")
 command_run("stat /home/ubuntu/reports.pdf")
-
+show_summary()

--- a/test/test_commands_ssh.py
+++ b/test/test_commands_ssh.py
@@ -2,7 +2,7 @@ from binnacle import *
 
 #mode2: ssh
 command_mode("ssh")
-command_node("192.168.29.65")
+command_node("192.168.29.65") #your VM IP
 command_ssh_user("test1")
 command_ssh_sudo(False) 
 command_ssh_pem_file("~/.ssh/id_rsa")
@@ -12,5 +12,3 @@ command_port("22")
 # unless command_node("local")
 command_run("cat /tmp/hello")
 show_summary()
-
-

--- a/test/test_rest_apis.py
+++ b/test/test_rest_apis.py
@@ -1,5 +1,8 @@
 from binnacle import *
+import os 
 
+
+#run server setup in server.py
 http_base_url("http://localhost:5001")
 
 # Without API Key
@@ -13,13 +16,9 @@ http_get("/api/v1/folders", status=401)
 http_set_header("x-api-key", "user_26a5fa8c7d8ad3729d218bcecf38c3aa9a7d4e40106072b4fd3f313af5c0682f")
 data = http_get("/api/v1/folders")
 debug(data)
+
 folders = validated_json(data)
-
-#compare_equal(len(folders), 4)
-#compare_not_equal(100, 100)
-
 validated_json('{"name": 100}')
 
-# command_run("ls /tmp")
 
 show_summary()


### PR DESCRIPTION
fixes issue #5 

This PR does the following:
1.  A new CLI entry point that serves as a starting point to run multiple test files or test files in a folder
2. Enable verbose logging